### PR TITLE
Filepath updates.

### DIFF
--- a/cmd/gopkg/gopkg.go
+++ b/cmd/gopkg/gopkg.go
@@ -32,7 +32,7 @@ func main() {
 	action := os.Args[1]
 	switch action {
 	case "make":
-		err = make2.Make(realPath)
+		err = make2.Make(os.Args[2])
 	case "build":
 		err = build.Build(realPath)
 	default:

--- a/cmd/gopkg/gopkg.go
+++ b/cmd/gopkg/gopkg.go
@@ -19,14 +19,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	realPath := os.Args[2]
-	if !filepath.IsAbs(realPath) {
-		wd, err := os.Getwd()
-		if err != nil {
-			log.Panic().Msg("failed to get working directory")
-		}
-		realPath = filepath.Join(wd, realPath)
-	}
+
 
 	var err error
 	action := os.Args[1]
@@ -34,6 +27,15 @@ func main() {
 	case "make":
 		err = make2.Make(os.Args[2])
 	case "build":
+		realPath := os.Args[2]
+		if !filepath.IsAbs(realPath) {
+			wd, err := os.Getwd()
+			if err != nil {
+				log.Panic().Msg("failed to get working directory")
+			}
+			realPath = filepath.Join(wd, realPath)
+		}
+
 		err = build.Build(realPath)
 	default:
 		err = fmt.Errorf("unknow action")

--- a/cmd/gopkg/gopkg.go
+++ b/cmd/gopkg/gopkg.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"os"
+	"path/filepath"
 )
 
 func main() {
@@ -18,13 +19,22 @@ func main() {
 		os.Exit(1)
 	}
 
+	realPath := os.Args[2]
+	if !filepath.IsAbs(realPath) {
+		wd, err := os.Getwd()
+		if err != nil {
+			log.Panic().Msg("failed to get working directory")
+		}
+		realPath = filepath.Join(wd, realPath)
+	}
+
 	var err error
 	action := os.Args[1]
 	switch action {
 	case "make":
-		err = make2.Make(os.Args[2])
+		err = make2.Make(realPath)
 	case "build":
-		err = build.Build(os.Args[2])
+		err = build.Build(realPath)
 	default:
 		err = fmt.Errorf("unknow action")
 	}

--- a/internal/control/changelog.go
+++ b/internal/control/changelog.go
@@ -5,6 +5,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 )
 
 const changelogFile = "changelog.yaml"
@@ -43,14 +44,14 @@ func writeChangelog(c Changelog, path string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(fmt.Sprintf("%s/%s", path, changelogFile), b, 0640)
+	return ioutil.WriteFile(filepath.Join(path, changelogFile), b, 0640)
 }
 
 // ReadChangelog read changelog from file
 func readChangelog(path string) (Changelog, error) {
 	var c Changelog
 
-	f, err := os.Open(fmt.Sprintf("%s/%s", path, changelogFile))
+	f, err := os.Open(filepath.Join(path, changelogFile))
 	if err != nil {
 		return Changelog{}, err
 	}

--- a/internal/control/metadata.go
+++ b/internal/control/metadata.go
@@ -5,6 +5,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 )
 
 const metadataFile = "metadata.yaml"
@@ -51,7 +52,7 @@ func writeMetadata(m Metadata, path string) error {
 func readMetadata(path string) (Metadata, error) {
 	var m Metadata
 
-	f, err := os.Open(fmt.Sprintf("%s/%s", path, metadataFile))
+	f, err := os.Open(filepath.Join(path, metadataFile))
 	if err != nil {
 		return Metadata{}, err
 	}


### PR DESCRIPTION
Changed a few occurrences from using fmt.sprintf to instead use filepath.Join, this to make sure that filepaths are correct on multiple platforms (specifically windows which uses different paths than unix-based systems).

Also updated the gopkg.go file to check if the "build dir" is an absolute or relative path, in case it is relative, it's changed into a absolute.