### PR TITLE
Fix for junk data in package read.

### DIFF
--- a/internal/pkg/package.go
+++ b/internal/pkg/package.go
@@ -84,8 +84,8 @@ func Read(path string) (map[string][]byte, error) {
 			return nil, err
 		}
 
-		out := bytes.NewBuffer(make([]byte, header.Size))
-		if _, err := io.Copy(out, tr); err != nil {
+		out := bytes.NewBuffer([]byte{})
+		if _, err := out.ReadFrom(tr); err != nil {
 			return nil, err
 		}
 

--- a/internal/pkg/package_test.go
+++ b/internal/pkg/package_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -129,13 +128,13 @@ func TestRead(t *testing.T) {
 	xmlContent := string(list["test/xmlfile.xml"])
 	txtContent := string(list["txtfile.txt"])
 
-	if strings.EqualFold(jsonContent, "This is a json file") {
+	if jsonContent != "This is a json file" {
 		t.Errorf("Json file could not be read.")
 	}
-	if strings.EqualFold(xmlContent, "This is an xml file") {
+	if xmlContent != "This is an xml file" {
 		t.Errorf("Xml file could not be read.")
 	}
-	if strings.EqualFold(txtContent, "This is a txt file") {
+	if txtContent != "This is a txt file" {
 		t.Errorf("Txt file could not be read.")
 	}
 


### PR DESCRIPTION
This PR fixes #31 by - instead of creating a buffer with the size of the expected result - creating a empty byte buffer which is then populated with `ReadFrom`.

Tests have been updated to be able to catch this in a better way as well.